### PR TITLE
Updated IPB hashcat hash number to 2811

### DIFF
--- a/data/prototypes.json
+++ b/data/prototypes.json
@@ -717,7 +717,7 @@
 			},
 			{
 				"john": null,
-				"hashcat": 2810,
+				"hashcat": 2811,
 				"extended": false,
 				"name": "IPB 2.x (Invision Power Board)",
 				"samples": [


### PR DESCRIPTION
Haiti currently lists this as 2810, but the actual hashtype for hashcat is 2811 (https://hashcat.net/wiki/doku.php?id=example_hashes)