### PR TITLE
Support Ruby 4.x.x and Bundler 4.x.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ group :runtime, :cli do
 end
 
 group :development, :install do
-  gem 'bundler', '~> 2.1'
+  gem 'bundler', '>= 2.1'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ GEM
   specs:
     asciidoctor (2.0.23)
     ast (2.4.3)
-    commonmarker (2.3.2-x86_64-linux)
+    commonmarker (2.6.0-x86_64-linux)
     docopt (0.6.1)
     json (2.13.2)
     language_server-protocol (3.17.0.5)
@@ -58,7 +58,7 @@ PLATFORMS
 
 DEPENDENCIES
   asciidoctor (~> 2.0)
-  bundler (~> 2.1)
+  bundler (>= 2.1)
   commonmarker (~> 2.0)
   docopt (~> 0.6)
   haiti-hash!
@@ -69,4 +69,4 @@ DEPENDENCIES
   yard!
 
 BUNDLED WITH
-   2.6.3
+  4.0.2

--- a/haiti.gemspec
+++ b/haiti.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
     'rubygems_mfa_required' => 'true'
   }
 
-  s.required_ruby_version = ['>= 3.1.0', '< 4.0']
+  s.required_ruby_version = ['>= 3.1.0', '< 5.0']
 
   s.add_runtime_dependency('docopt', '~> 0.6') # for argument parsing
   s.add_runtime_dependency('paint', '~> 2.3') # for colorized output

--- a/test/test_haiti.rb
+++ b/test/test_haiti.rb
@@ -3,6 +3,7 @@
 require 'minitest/autorun'
 require 'haiti'
 
+# Unit tests for the HashIdentifier library
 class HaitiTest < Minitest::Test
   def setup
     @hash = '5f4dcc3b5aa765d61d8327deb882cf99'


### PR DESCRIPTION
We're bumping Ruby to 4.0.0 in Homebrew and I noticed `haiti` fails to build due to the Ruby and Bundler constraints. `bundle exec rake test` and `bundle exec rubocop` were both successful.